### PR TITLE
[feature/dev_python] mokztk/RStudio_docker から python/pandas/matplotlib のインストールスクリプトを流用

### DIFF
--- a/mr_scripts/install_pandas.sh
+++ b/mr_scripts/install_pandas.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -x
+
+# R から {reticulate} で Python3 を使えるようにセットアップ
+
+# Python3のインストール
+source /rocker_scripts/install_python.sh
+
+# aptキャッシュを消去
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+# グローバルに pandas と matplotlib/seaborn を入れておく
+pip install pandas seaborn


### PR DESCRIPTION
rocker project で用意されている python3/reticulate のインストールスクリプトを利用
仮想環境は作らず、グローバルに pandas, matplotlib/seaborn を導入