### PR TITLE
[feature/dev_tex] mokztk/RStudio_docker から TinyTeX のインストールスクリプトを流用

### DIFF
--- a/mr_scripts/install_tex_packages.sh
+++ b/mr_scripts/install_tex_packages.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# XeLaTeX + BXjscls で日本語PDFを作成するのに必要なパッケージのインストール
+
+/home/rstudio/.TinyTeX/bin/x86_64-linux/tlmgr install \
+    bxjscls \
+    zxjatype \
+    zxjafont \
+    adobemapping \
+    amscls \
+    arphic \
+    beamer \
+    cjk \
+    cjkpunct \
+    cns \
+    ctablestack \
+    ctex \
+    everyhook \
+    fandol \
+    fonts-tlwg \
+    fp \
+    garuda-c90 \
+    latex-base-dev \
+    luatexbase \
+    luatexja \
+    mptopdf.x86_64-linux \
+    mptopdf \
+    ms \
+    norasi-c90 \
+    pgf \
+    platex.x86_64-linux \
+    platex \
+    platex-tools \
+    ptex.x86_64-linux \
+    ptex \
+    ptex-base \
+    ptex-fonts \
+    svn-prov \
+    translator \
+    ttfutils.x86_64-linux \
+    ttfutils \
+    uhc \
+    ulem \
+    uplatex.x86_64-linux \
+    uplatex \
+    uptex.x86_64-linux \
+    uptex \
+    uptex-base \
+    uptex-fonts \
+    wadalab \
+    xcjk2uni \
+    xecjk \
+    xpinyin \
+    zhmetrics \
+    zhmetrics-uptex \
+    zhnumber
+
+/home/rstudio/.TinyTeX/bin/x86_64-linux/tlmgr path add

--- a/mr_scripts/install_tinytex.sh
+++ b/mr_scripts/install_tinytex.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# TinyTex本体のインストール
+# 当面、FREEZEとなった TeXLive 2020 アーカイブを利用する
+
+Rscript -e 'tinytex::install_tinytex(dir = "/home/rstudio/.TinyTeX/", version = "2021.03", repository = "https://texlive.texjp.org/2020/tlnet")'
+
+# 一部の package 用にLaTeXコンパイラの場所を指定
+echo "R_LATEXCMD=/home/rstudio/.TinyTeX/bin/x86_64-linux/platex" >> /home/rstudio/.Renviron
+echo "R_PDFLATEXCMD=/home/rstudio/.TinyTeX/bin/x86_64-linux/pdflatex" >> /home/rstudio/.Renviron


### PR DESCRIPTION
2021-03 に freeze となった TeXLive 2020 を利用するために
- TinyTeX は バージョン 2021.03 を指定
- TeXLive のレポジトリは texlive.texjp.org の TeXLive2020 アーカイブを指定