### PR TITLE
[feature/dev_r_packages] fix : Bioconductior のインストール元を公式に戻す

### DIFF
--- a/mr_scripts/install_r_packages.sh
+++ b/mr_scripts/install_r_packages.sh
@@ -38,10 +38,7 @@ R CMD javareconf
 # RSPMのcheckpointが変わった場合に対応するため、まずcheckpointの状態まで更新する
 Rscript -e "update.packages(ask = FALSE)"
 
-# Bioconductor もRSPMからインストールする
-echo "options(BioC_mirror = 'https://packagemanager.rstudio.com/bioconductor')" >> /usr/local/lib/R/etc/Rprofile.site
-
-# 依存関係でCRAN/RSPMにないものを先にインストール
+# 依存関係でCRAN/RSPMにないもの（Bioconductor）を先にインストール
 Rscript -e "BiocManager::install(c('limma'))"
 
 # CRANパッケージをRSPMからインストール


### PR DESCRIPTION
sessioninfo::package_info() などで見るときに、インストール元が Bioconductor とわかるように。
RSPM からでも公式からでも、インストールされるバージョンは同じ